### PR TITLE
feat: 다크모드 & 스타일링 에셋 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.1.4",
+        "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -4110,6 +4111,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.4.tgz",
+      "integrity": "sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "15.1.4",
+    "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,77 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --color-gray-100: #f8fafb;
+  --color-gray-200: #f2f4f5;
+  --color-gray-300: #eaeced;
+  --color-gray-400: #dbddde;
+  --color-gray-500: #b7b9bb;
+  --color-gray-600: #989a9b;
+  --color-gray-700: #6f7172;
+  --color-gray-800: #3d3f40;
+  --color-gray-900: #1d1d1d;
+  --color-yellow-100: #fdfce9;
+  --color-yellow-200: #fbf7c8;
+  --color-yellow-300: #f9f2a5;
+  --color-yellow-400: #fffa95;
+  --color-yellow-500: #f5e96a;
+  --color-yellow-600: #f3e34e;
+  --color-yellow-700: #f2d44b;
+  --color-yellow-800: #efbd43;
+  --color-yellow-900: #eba73a;
+  --color-blue-100: #e7ebff;
+  --color-blue-200: #c3cdfe;
+  --color-blue-300: #97adfe;
+  --color-blue-400: #638dff;
+  --color-blue-500: #4f6df1;
+  --color-blue-600: #3456ec;
+  --color-blue-700: #013dd4;
+  --color-blue-800: #0131c9;
+  --color-blue-900: #001bb1;
+  --color-system-red: #ff4242;
+  --color-system-green: #03bf40;
+  --shadow-normal: 0px 1px 10px 0px rgba(0, 0, 0, 0.12),
+    0px 0px 1px 0px rgba(0, 0, 0, 0.08), 0px 0px 1px 0px rgba(0, 0, 0, 0.08);
+  --shadow-emphasize: 0px 2px 8px 0px rgba(183, 185, 187, 0.5),
+    0px 1px 4px 0px rgba(152, 154, 155, 0.3),
+    0px 0px 2px 0px rgba(152, 154, 155, 0.2);
+}
+
+.dark {
+  --color-gray-100: #1d1d1d;
+  --color-gray-200: #28292a;
+  --color-gray-300: #464848;
+  --color-gray-400: #5f6162;
+  --color-gray-500: #7e8081;
+  --color-gray-600: #9aa0a2;
+  --color-gray-700: #c8cdd0;
+  --color-gray-800: #dce2e4;
+  --color-gray-900: #ecf1f4;
+  --color-yellow-100: #dba34a;
+  --color-yellow-200: #e3b844;
+  --color-yellow-300: #eec14b;
+  --color-yellow-400: #f5cc55;
+  --color-yellow-500: #f7d46a;
+  --color-yellow-600: #fce08c;
+  --color-yellow-700: #fde9a4;
+  --color-yellow-800: #f6f3cd;
+  --color-yellow-900: #fbfaeb;
+  --color-blue-100: #293365;
+  --color-blue-200: #253eae;
+  --color-blue-300: #2f4ebf;
+  --color-blue-400: #3a5fd9;
+  --color-blue-500: #466be0;
+  --color-blue-600: #5278f5;
+  --color-blue-700: #9eb1f7;
+  --color-blue-800: #c7cffa;
+  --color-blue-900: #e9ecfd;
+  --color-system-red: #ff6363;
+  --color-system-green: #1ed45a;
+  --shadow-normal: 0px 1px 2px 0px rgba(0, 0, 0, 0.12),
+    0px 0px 2px 0px rgba(0, 0, 0, 0.12);
+  --shadow-emphasize: 0px 0px 0px 0px rgba(183, 185, 187, 0.5),
+    0px 1px 4px 0px rgba(152, 154, 155, 0.3),
+    0px 0px 2px 0px rgba(152, 154, 155, 0.2);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -23,9 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <ThemeProvider attribute="class">{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,105 @@
+import ThemeSwitch from "@/components/ThemeSwitch";
+
 export default function Home() {
-  return <div className="text-red-600">보도 블록 가보자구우</div>;
+  return (
+    <div>
+      <ThemeSwitch />
+
+      <div className="flex">
+        <div className="flex-1">
+          <p className="text-headline-1-bold text-blue-900">
+            text-headline-1-bold
+          </p>
+          <p className="text-headline-1-regular text-blue-800">
+            text-headline-1-regular
+          </p>
+          <p className="text-headline-2-bold text-blue-700">
+            text-headline-2-bold
+          </p>
+          <p className="text-headline-2-regular text-blue-600">
+            text-headline-2-regular
+          </p>
+          <p className="text-headline-3-bold text-blue-500">
+            text-headline-3-bold
+          </p>
+          <p className="text-headline-3-regular text-blue-400">
+            text-headline-3-regular
+          </p>
+          <p className="text-headline-4-bold text-blue-300">
+            text-headline-4-bold
+          </p>
+          <p className="text-headline-4-semibold text-blue-200">
+            text-headline-4-semibold
+          </p>
+          <p className="text-headline-4-medium text-blue-100">
+            text-headline-4-medium
+          </p>
+
+          <p className="text-title-1-bold text-yellow-900">text-title-1-bold</p>
+          <p className="text-title-1-semibold text-yellow-800">
+            text-title-1-semibold
+          </p>
+          <p className="text-title-1-medium text-yellow-700">
+            text-title-1-medium
+          </p>
+          <p className="text-title-1-regular text-yellow-600">
+            text-title-1-regular
+          </p>
+          <p className="text-title-2-semibold text-yellow-500">
+            text-title-2-semibold
+          </p>
+          <p className="text-title-2-medium text-yellow-400">
+            text-title-2-medium
+          </p>
+          <p className="text-title-2-regular text-yellow-300">
+            text-title-2-regular
+          </p>
+          <p className="text-title-3-semibold text-yellow-200">
+            text-title-3-semibold
+          </p>
+          <p className="text-title-3-medium text-yellow-100">
+            text-title-3-medium
+          </p>
+
+          <p className="text-body-1-semibold text-gray-900">
+            text-body-1-semibold
+          </p>
+          <p className="text-body-1-medium text-gray-800">text-body-1-medium</p>
+          <p className="text-body-1-regular text-gray-700">
+            text-body-1-regular
+          </p>
+          <p className="text-body-2-semibold text-gray-600">
+            text-body-2-semibold
+          </p>
+          <p className="text-body-2-medium text-gray-500">text-body-2-medium</p>
+          <p className="text-body-2-regular text-gray-400">
+            text-body-2-regular
+          </p>
+          <p className="text-body-3-semibold text-gray-300">
+            text-body-3-semibold
+          </p>
+          <p className="text-body-3-medium text-gray-200">text-body-3-medium</p>
+          <p className="text-body-3-regular text-gray-100">
+            text-body-3-regular
+          </p>
+
+          <p className="text-caption-1-semibold text-system-red">
+            text-caption-1-semibold
+          </p>
+          <p className="text-caption-1-regular text-system-green">
+            text-caption-1-regular
+          </p>
+        </div>
+
+        <div className="flex-1 flex gap-8">
+          <div className="w-[10rem] h-[10rem] shadow-normal flex items-center justify-center">
+            shadow-normal
+          </div>
+          <div className="w-[10rem] h-[10rem] shadow-emphasize flex items-center justify-center">
+            shadow-emphasize
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+const ThemeSwitch = () => {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+      <option value="system">System</option>
+      <option value="dark">Dark</option>
+      <option value="light">Light</option>
+    </select>
+  );
+};
+
+export default ThemeSwitch;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,9 +5,9 @@ module.exports = {
   theme: {
     extend: {
       screens: {
-        mobile: { max: "759px" },
-        tablet: { min: "760px", max: "1023px" },
-        desktop: { min: "1024px" },
+        mobile: { max: "767px" },
+        tablet: { min: "768px", max: "1439px" },
+        desktop: { min: "1440px" },
       },
       colors: {
         "gray-100": "var(--color-gray-100)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,306 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        mobile: { max: "759px" },
+        tablet: { min: "760px", max: "1023px" },
+        desktop: { min: "1024px" },
+      },
+      colors: {
+        "gray-100": "var(--color-gray-100)",
+        "gray-200": "var(--color-gray-200)",
+        "gray-300": "var(--color-gray-300)",
+        "gray-400": "var(--color-gray-400)",
+        "gray-500": "var(--color-gray-500)",
+        "gray-600": "var(--color-gray-600)",
+        "gray-700": "var(--color-gray-700)",
+        "gray-800": "var(--color-gray-800)",
+        "gray-900": "var(--color-gray-900)",
+        "yellow-100": "var(--color-yellow-100)",
+        "yellow-200": "var(--color-yellow-200)",
+        "yellow-300": "var(--color-yellow-300)",
+        "yellow-400": "var(--color-yellow-400)",
+        "yellow-500": "var(--color-yellow-500)",
+        "yellow-600": "var(--color-yellow-600)",
+        "yellow-700": "var(--color-yellow-700)",
+        "yellow-800": "var(--color-yellow-800)",
+        "yellow-900": "var(--color-yellow-900)",
+        "blue-100": "var(--color-blue-100)",
+        "blue-200": "var(--color-blue-200)",
+        "blue-300": "var(--color-blue-300)",
+        "blue-400": "var(--color-blue-400)",
+        "blue-500": "var(--color-blue-500)",
+        "blue-600": "var(--color-blue-600)",
+        "blue-700": "var(--color-blue-700)",
+        "blue-800": "var(--color-blue-800)",
+        "blue-900": "var(--color-blue-900)",
+        "system-red": "var(--color-system-red)",
+        "system-green": "var(--color-system-green)",
+        white: "#FFFFFF",
+        dark: "#0E0E0E",
+      },
+      fontSize: {
+        // headline
+        "headline-1-bold": [
+          "40px",
+          {
+            fontWeight: "700",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "headline-1-regular": [
+          "40px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "headline-2-bold": [
+          "36px",
+          {
+            fontWeight: "700",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.34",
+          },
+        ],
+        "headline-2-regular": [
+          "36px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.34",
+          },
+        ],
+        "headline-3-bold": [
+          "32px",
+          {
+            fontWeight: "700",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        "headline-3-regular": [
+          "32px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        "headline-4-bold": [
+          "28px",
+          {
+            fontWeight: "700",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        "headline-4-semibold": [
+          "28px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        "headline-4-medium": [
+          "28px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        "headline-4-regular": [
+          "28px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.36",
+          },
+        ],
+        // title
+        "title-1-bold": [
+          "24px",
+          {
+            fontWeight: "700",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-1-semibold": [
+          "24px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-1-medium": [
+          "24px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-1-regular": [
+          "24px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-2-semibold": [
+          "20px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-2-medium": [
+          "20px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-2-regular": [
+          "20px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.4",
+          },
+        ],
+        "title-3-semibold": [
+          "18px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.445",
+          },
+        ],
+        "title-3-medium": [
+          "18px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.445",
+          },
+        ],
+        "title-3-regular": [
+          "18px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.445",
+          },
+        ],
+        // body
+        "body-1-semibold": [
+          "16px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        "body-1-medium": [
+          "16px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        "body-1-regular": [
+          "16px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        "body-2-semibold": [
+          "14px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.6",
+          },
+        ],
+        "body-2-medium": [
+          "14px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.6",
+          },
+        ],
+        "body-2-regular": [
+          "14px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.6",
+          },
+        ],
+        "body-3-semibold": [
+          "12px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        "body-3-medium": [
+          "12px",
+          {
+            fontWeight: "500",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        "body-3-regular": [
+          "12px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.5",
+          },
+        ],
+        // caption
+        "caption-1-semibold": [
+          "10px",
+          {
+            fontWeight: "600",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.6",
+          },
+        ],
+        "caption-1-regular": [
+          "10px",
+          {
+            fontWeight: "400",
+            letterSpacing: "-1.1px",
+            lineHeight: "1.6",
+          },
+        ],
+      },
+      boxShadow: {
+        normal: "var(--shadow-normal)",
+        emphasize: "var(--shadow-emphasize)",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 문제/이슈/주제: 다크모드 & 스타일링 에셋 작업

### 시안

https://www.figma.com/design/t0XR2VIwUeA5P0GZCNUHWm/%EB%B9%8C%EB%8D%94%EB%B8%94%EB%A1%9D_%EC%A0%84%EC%B2%B4?node-id=226-3039&p=f&m=dev

### 개발

1. next-theme 의존성 패키지 설치

- cc. https://www.npmjs.com/package/next-themes

2. 컬러, 폰트, 그림자 효과 에셋 준비 & 다크모드 기본 적용 

- tailwind.config.js 에 colors, fontSize, boxShadow, screen 에 대한 에셋 설정
- colors, boxShadow 의 경우는 다크 모드일 때 className 개별적 등록하기 싫어서 theme mode 에 따라 자동으로 반영되도록 css variable 을 global.css 에 `:root`, `.dark` 로 구분

- 기능

  > - [x] theme mode 변경 시, light / dark 모드에 맞는 스타일 에셋이 적용되는지