### PR TITLE
QA : 소식 페이지 - 이벤트 섹션

### DIFF
--- a/src/app/information/components/BlockchainEventSection/BlockchainEventList.tsx
+++ b/src/app/information/components/BlockchainEventSection/BlockchainEventList.tsx
@@ -10,10 +10,12 @@ const BlockchainEventList = ({
   blockchainEventList,
   blockchainEventType,
   swiperRef,
+  scrollRef,
 }: {
   blockchainEventList: TBlockchainInformationData[];
   blockchainEventType: TBlockchainInformationType;
   swiperRef: RefObject<SwiperRef | null>;
+  scrollRef: RefObject<HTMLUListElement | null>;
 }) => {
   const blockchainEventListChunk = generate2DData({ data: blockchainEventList });
 
@@ -35,7 +37,10 @@ const BlockchainEventList = ({
         })}
       </Swiper>
 
-      <ul className="grid grid-flow-col grid-rows-2 gap-[2rem] overflow-x-auto pl-[4rem] pr-[2rem] scrollbar-hide md:hidden mobile:pl-[2rem]">
+      <ul
+        ref={scrollRef}
+        className="grid grid-flow-col grid-rows-2 gap-[2rem] overflow-x-auto pl-[4rem] pr-[2rem] scrollbar-hide md:hidden mobile:pl-[2rem]"
+      >
         {blockchainEventList.map((blockchainEvent) => {
           return (
             <li key={`${blockchainEvent.id}-${blockchainEvent.sourceIndex}`}>

--- a/src/app/information/components/BlockchainEventSection/BlockchainEventSection.client.tsx
+++ b/src/app/information/components/BlockchainEventSection/BlockchainEventSection.client.tsx
@@ -21,6 +21,7 @@ const BlockchainEventSectionClient = ({
   hackathonList: TBlockchainInformationData[];
   meetupList: TBlockchainInformationData[];
 }) => {
+  const scrollRef = useRef<HTMLUListElement | null>(null);
   const swiperRef = useRef<SwiperRef>(null);
   const [currentEventTabValue, setCurrentEventTabValue] = useState<TEventTab>(eventTabList[0].value);
   const [currentPage, setCurrentPage] = useState(1);
@@ -35,6 +36,10 @@ const BlockchainEventSectionClient = ({
       setCurrentEventTabValue(selectedEventTab);
       setCurrentPage(1);
       swiperRef.current.swiper.slideTo(0, 0);
+    }
+
+    if (scrollRef && scrollRef.current) {
+      scrollRef.current.scrollTo(0, 0);
     }
   };
 
@@ -96,6 +101,7 @@ const BlockchainEventSectionClient = ({
           blockchainEventType={currentEventTabValue}
           blockchainEventList={currentEventTabValue === 'hackathon' ? hackathonList : meetupList}
           swiperRef={swiperRef}
+          scrollRef={scrollRef}
         />
       </div>
     </div>

--- a/src/app/information/components/BlockchainEventSection/BlockchainEventSection.client.tsx
+++ b/src/app/information/components/BlockchainEventSection/BlockchainEventSection.client.tsx
@@ -26,7 +26,7 @@ const BlockchainEventSectionClient = ({
   const [currentPage, setCurrentPage] = useState(1);
 
   const maxPage = useMemo(
-    () => Math.floor((currentEventTabValue === 'hackathon' ? hackathonList.length : meetupList.length) / 4),
+    () => Math.ceil((currentEventTabValue === 'hackathon' ? hackathonList.length : meetupList.length) / 4),
     [hackathonList, meetupList, currentEventTabValue]
   );
 


### PR DESCRIPTION
## 문제/이슈/주제: QA : 소식 페이지 - 이벤트 섹션

### 개발

- [해커톤 개수가 화면 크기에 따라 상이하게 보이는 현상](https://www.notion.so/teamnexters/15-19b235c592d980ccbbe0c06bc2c65fc5?pvs=4)
- [작은 화면에서 소식 > 이벤트 카테고리 변경시 스크롤 위치가 유지되는 현상](https://www.notion.so/teamnexters/18-19b235c592d9807bb184c1c24e84bed9?pvs=4)

- 기능

  > - [x] Swipe 방식과 스크롤 방식일 때 이벤트 섹션 아이템 수가 같은지
  > - [x] 스크롤 방식일 때 스크롤 하다가 탭 변경 시 스크롤이 초기화되는지

